### PR TITLE
Update Webpack config for PostCSS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,6 @@ body.some-selector {
 Use it like you'd use any other PostCSS plugin. If you also have `autoprefixer` in your webpack config then make sure that `postcss-prefix-selector` is called first. This is needed to avoid running the prefixer twice on both standard selectors and vendor specific ones (ex: `@keyframes` and `@webkit-keyframes`).
 
 ```js
-const prefixer = require('postcss-prefix-selector');
-
 module: {
   rules: [{
     test: /\.css$/,
@@ -98,14 +96,16 @@ module: {
       {
         loader: require.resolve('postcss-loader'),
         options: {
-          plugins: () => [
-            prefixer({
-              prefix: '.my-prefix'
-            }),
-            autoprefixer({
-              browsers: ['last 4 versions']
-            })
-          ]
+          postcssOptions: {
+            plugins: {
+              "postcss-prefix-selector": {
+                prefix: '.my-prefix'
+              },
+              autoprefixer: {
+                browsers: ['last 4 versions']
+              }
+            }
+          }
         }
       }
     ]


### PR DESCRIPTION
Hello!

I'm in the process of upgrading a lot of dependencies in my own projects and this is the change I had to make in my webpack.config.js to get this PostCSS plugin working with the new PostCSS 8 and the latest version of the Webpack postcss-loader, per the example at https://github.com/webpack-contrib/postcss-loader#getting-started

I can confirm that this works for my own project, whereas the old config didn't work. Please let me know your thoughts.