### PR TITLE
Move plugin to visitor API

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,23 +6,24 @@ module.exports = function postcssPrefixSelector(options) {
     ? [].concat(options.includeFiles)
     : [];
 
-  return function (root) {
-    if (
-      ignoreFiles.length &&
-      root.source.input.file &&
-      isFileInArray(root.source.input.file, ignoreFiles)
-    ) {
-      return;
-    }
-    if (
-      includeFiles.length &&
-      root.source.input.file &&
-      !isFileInArray(root.source.input.file, includeFiles)
-    ) {
-      return;
-    }
+  return {
+    postcssPlugin: 'postcss-prefix-selector',
+    Rule(rule) {
+      if (
+        ignoreFiles.length &&
+        rule.source.input.file &&
+        isFileInArray(rule.source.input.file, ignoreFiles)
+      ) {
+        return;
+      }
+      if (
+        includeFiles.length &&
+        rule.source.input.file &&
+        !isFileInArray(rule.source.input.file, includeFiles)
+      ) {
+        return;
+      }
 
-    root.walkRules((rule) => {
       const keyframeRules = [
         'keyframes',
         '-webkit-keyframes',
@@ -49,7 +50,7 @@ module.exports = function postcssPrefixSelector(options) {
 
         return prefixWithSpace + selector;
       });
-    });
+    },
   };
 };
 


### PR DESCRIPTION
Since `postcss-nested` moved to visitor API (in version 5.0.2) there is a problem with correctness of processing nested rules using this plugin.
This problem discussed in more details in https://github.com/postcss/postcss/issues/1611#issue-934800901

So I tried to fix it by moving your plugin to visitor API too and this fixed problem. All test in repo was passed but maybe you have additional checks