### PR TITLE
fix: deps `dependencies` -> `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "repository": "RadValentin/postcss-prefix-selector",
   "bugs": "https://github.com/RadValentin/postcss-prefix-selector/issues",
   "homepage": "https://github.com/RadValentin/postcss-prefix-selector",
-  "dependencies": {
-    "postcss": "^8.3.6"
+  "peerDependencies": {
+    "postcss": "7.x || 8.x"
   },
   "devDependencies": {
     "husky": "^4.0.2",


### PR DESCRIPTION
My project is `postcss 7.x`, but the `dependencies` version declared in the package causes problems. After testing, both `7.x` and `8.x` apply. Change to `peerDependencies`