### PR TITLE
Transform access to Rule/Root

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const out = postcss().use(prefixer({
   exclude: ['.c'],
 
   // Optional transform callback for case-by-case overrides
-  transform: function (prefix, selector, prefixedSelector) {
+  transform: function (prefix, selector, prefixedSelector, filePath, rule) {
     if (selector === 'body') {
       return 'body' + prefix;
     } else {
@@ -98,13 +98,18 @@ module: {
             plugins: {
               "postcss-prefix-selector": {
                 prefix: '.my-prefix',
-                transform(prefix, selector, prefixedSelector, filepath) {
+                transform(prefix, selector, prefixedSelector, filePath, rule) {
                   if (selector.match(/^(html|body)/)) {
                     return selector.replace(/^([^\s]*)/, `$1 ${prefix}`);
                   }
                   
-                  if (filepath.match(/node_modules/)) {
+                  if (filePath.match(/node_modules/)) {
                     return selector; // Do not prefix styles imported from node_modules
+                  }
+                  
+                  const annotation = rule.prev();
+                  if (annotation?.type === 'comment' && annotation.text.trim() === 'no-prefix') {
+                    return selector; // Do not prefix style rules that are preceded by: /* no-prefix */
                   }
 
                   return prefixedSelector;

--- a/index.js
+++ b/index.js
@@ -44,7 +44,8 @@ module.exports = function postcssPrefixSelector(options) {
             prefix,
             selector,
             prefixWithSpace + selector,
-            root.source.input.file
+            root.source.input.file,
+            rule
           );
         }
 

--- a/test/fixtures/transform-by-rule-root.css
+++ b/test/fixtures/transform-by-rule-root.css
@@ -1,29 +1,35 @@
-body.hello {
+/* no-prefix-for:.class-ignored-by-root */
+
+body {
   margin: 0;
   padding: 0;
 }
 
-.hello .a,
-.hello .b {
+.a,
+.b {
   color: red;
 }
 
-.hello .a *:not(.b) {
+.a *:not(.b) {
   text-transform: uppercase;
 }
 
-.hello .c {
+.c {
   font-size: 10px;
 }
 
-.hello .class-a {
+.class-a {
   color: coral;
 }
 
-.hello .class-b {
+.class-b {
   color: deepskyblue;
 }
 
-.hello [data-world] .d {
+[data-world] .d {
   padding: 10px 20px;
+}
+
+.class-ignored-by-root {
+  color: peru;
 }

--- a/test/fixtures/transform-by-rule-root.expected.css
+++ b/test/fixtures/transform-by-rule-root.expected.css
@@ -1,4 +1,6 @@
-body.hello {
+/* no-prefix-for:.class-ignored-by-root */
+
+.hello body {
   margin: 0;
   padding: 0;
 }
@@ -26,4 +28,8 @@ body.hello {
 
 .hello [data-world] .d {
   padding: 10px 20px;
+}
+
+.class-ignored-by-root {
+  color: peru;
 }

--- a/test/fixtures/transform-by-rule.css
+++ b/test/fixtures/transform-by-rule.css
@@ -1,29 +1,34 @@
-body.hello {
+body {
   margin: 0;
   padding: 0;
 }
 
-.hello .a,
-.hello .b {
+.a,
+.b {
   color: red;
 }
 
-.hello .a *:not(.b) {
+.a *:not(.b) {
   text-transform: uppercase;
 }
 
-.hello .c {
+.c {
   font-size: 10px;
 }
 
-.hello .class-a {
+.class-a {
   color: coral;
 }
 
-.hello .class-b {
+.class-b {
   color: deepskyblue;
 }
 
-.hello [data-world] .d {
+[data-world] .d {
   padding: 10px 20px;
+}
+
+/* no-prefix */
+.class-ignore {
+  color: hotpink;
 }

--- a/test/fixtures/transform-by-rule.expected.css
+++ b/test/fixtures/transform-by-rule.expected.css
@@ -1,4 +1,4 @@
-body.hello {
+.hello body {
   margin: 0;
   padding: 0;
 }
@@ -26,4 +26,9 @@ body.hello {
 
 .hello [data-world] .d {
   padding: 10px 20px;
+}
+
+/* no-prefix */
+.class-ignore {
+  color: hotpink;
 }

--- a/test/fixtures/transform.css
+++ b/test/fixtures/transform.css
@@ -1,5 +1,3 @@
-/* no-prefix-for:.class-ignored-by-root */
-
 body {
   margin: 0;
   padding: 0;
@@ -28,13 +26,4 @@ body {
 
 [data-world] .d {
   padding: 10px 20px;
-}
-
-/* no-prefix */
-.class-ignore {
-  color: hotpink;
-}
-
-.class-ignored-by-root {
-  color: peru;
 }

--- a/test/fixtures/transform.css
+++ b/test/fixtures/transform.css
@@ -1,3 +1,5 @@
+/* no-prefix-for:.class-ignored-by-root */
+
 body {
   margin: 0;
   padding: 0;
@@ -26,4 +28,13 @@ body {
 
 [data-world] .d {
   padding: 10px 20px;
+}
+
+/* no-prefix */
+.class-ignore {
+  color: hotpink;
+}
+
+.class-ignored-by-root {
+  color: peru;
 }

--- a/test/fixtures/transform.expected.css
+++ b/test/fixtures/transform.expected.css
@@ -1,3 +1,5 @@
+/* no-prefix-for:.class-ignored-by-root */
+
 body.hello {
   margin: 0;
   padding: 0;
@@ -26,4 +28,13 @@ body.hello {
 
 .hello [data-world] .d {
   padding: 10px 20px;
+}
+
+/* no-prefix */
+.class-ignore {
+  color: hotpink;
+}
+
+.class-ignored-by-root {
+  color: peru;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -66,7 +66,7 @@ it('should support an additional callback for prefix transformation', () => {
     .use(
       prefixer({
         prefix: '.hello',
-        transform(prefix, selector, prefixedSelector, fileName, rule) {
+        transform(prefix, selector, prefixedSelector, filePath, rule) {
           if (selector === 'body') {
             return `body${prefix}`;
           }
@@ -87,11 +87,10 @@ it('should support an additional callback for prefix transformation to check a n
     .use(
       prefixer({
         prefix: '.hello',
-        transform(prefix, selector, prefixedSelector, fileName, rule) {
+        transform(prefix, selector, prefixedSelector, filePath, rule) {
           const annotation = rule.prev();
           if (
-            typeof annotation !== 'undefined' &&
-            annotation.type === 'comment' &&
+            annotation?.type === 'comment' &&
             annotation.text.trim() === 'no-prefix'
           ) {
             return selector;
@@ -113,7 +112,7 @@ it('should support an additional callback for prefix transformation to check a n
     .use(
       prefixer({
         prefix: '.hello',
-        transform(prefix, selector, prefixedSelector, fileName, rule) {
+        transform(prefix, selector, prefixedSelector, filePath, rule) {
           const root = rule.root();
           if (
             root.first.type === 'comment' &&

--- a/test/test.js
+++ b/test/test.js
@@ -71,16 +71,49 @@ it('should support an additional callback for prefix transformation', () => {
             return `body${prefix}`;
           }
 
-          // Test if it can see previous nodes
+          return prefixedSelector;
+        },
+      })
+    )
+    .process(getFixtureContents('transform.css')).css;
+
+  const expected = getFixtureContents('transform.expected.css');
+
+  assert.equal(out, expected);
+});
+
+it('should support an additional callback for prefix transformation to check a node before the rule', () => {
+  const out = postcss()
+    .use(
+      prefixer({
+        prefix: '.hello',
+        transform(prefix, selector, prefixedSelector, fileName, rule) {
           const annotation = rule.prev();
           if (
+            typeof annotation !== 'undefined' &&
             annotation.type === 'comment' &&
             annotation.text.trim() === 'no-prefix'
           ) {
             return selector;
           }
 
-          // Test if it can reach the first node through root
+          return prefixedSelector;
+        },
+      })
+    )
+    .process(getFixtureContents('transform-by-rule.css')).css;
+
+  const expected = getFixtureContents('transform-by-rule.expected.css');
+
+  assert.equal(out, expected);
+});
+
+it('should support an additional callback for prefix transformation to check a node at root', () => {
+  const out = postcss()
+    .use(
+      prefixer({
+        prefix: '.hello',
+        transform(prefix, selector, prefixedSelector, fileName, rule) {
           const root = rule.root();
           if (
             root.first.type === 'comment' &&
@@ -93,9 +126,9 @@ it('should support an additional callback for prefix transformation', () => {
         },
       })
     )
-    .process(getFixtureContents('transform.css')).css;
+    .process(getFixtureContents('transform-by-rule-root.css')).css;
 
-  const expected = getFixtureContents('transform.expected.css');
+  const expected = getFixtureContents('transform-by-rule-root.expected.css');
 
   assert.equal(out, expected);
 });

--- a/test/test.js
+++ b/test/test.js
@@ -66,9 +66,27 @@ it('should support an additional callback for prefix transformation', () => {
     .use(
       prefixer({
         prefix: '.hello',
-        transform(prefix, selector, prefixedSelector) {
+        transform(prefix, selector, prefixedSelector, fileName, rule) {
           if (selector === 'body') {
             return `body${prefix}`;
+          }
+
+          // Test if it can see previous nodes
+          const annotation = rule.prev();
+          if (
+            annotation.type === 'comment' &&
+            annotation.text.trim() === 'no-prefix'
+          ) {
+            return selector;
+          }
+
+          // Test if it can reach the first node through root
+          const root = rule.root();
+          if (
+            root.first.type === 'comment' &&
+            root.first.text.trim() === 'no-prefix-for:' + selector
+          ) {
+            return selector;
           }
 
           return prefixedSelector;


### PR DESCRIPTION
In issue #108 we discussed getting access to the raw postcss Root in the transform callback. While I was working on this I realized that you can get Root from a Rule (Rule#root). Giving the user access to the current Rule therefor opens up even more options.

I have added tests that also demonstrate why this feature is useful.

If you don't mind making a breaking change I would consider removing this line: https://github.com/luttje/postcss-prefix-selector/blob/c61250e46d63f34913702253f076de72a0daa730/index.js#L47 Since that can now be reached through `rule.root.source.input.file`

Let me know if I need to add/change something. If you think it's all good, let me know and I'll add a bit of explanation to the README as well. 